### PR TITLE
Fix deprecated import for python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/amass/__init__.py
+++ b/amass/__init__.py
@@ -164,11 +164,23 @@ class UNPKGDependencyProvider(DependencyProvider):
             ) as response:
                 metadata = await response.json()
 
+        ALLOWED_ASSET_TYPES = {
+            "text/html",
+            "text/javascript",
+            "text/markdown",
+            "text/plain",
+            "text/typescript",
+            "text/yaml",
+            "application/json",
+            "application/octet-stream",
+            "application/toml",
+        }
+
         assets = []
 
         def append_assets(data: Dict[str, Any]) -> None:
             for file in data["files"]:
-                if file["type"] == "file":
+                if file["type"] in ALLOWED_ASSET_TYPES:
                     assets.append(
                         AssetFile(
                             name=file["path"].lstrip("/"),

--- a/amass/__init__.py
+++ b/amass/__init__.py
@@ -124,6 +124,19 @@ class CDNJSDependencyProvider(DependencyProvider):
         return content
 
 
+UNPKG_ALLOWED_ASSET_TYPES = {
+    "text/html",
+    "text/javascript",
+    "text/markdown",
+    "text/plain",
+    "text/typescript",
+    "text/yaml",
+    "application/json",
+    "application/octet-stream",
+    "application/toml",
+}
+
+
 class UNPKGDependencyProvider(DependencyProvider):
     @staticmethod
     async def get_versions(
@@ -164,23 +177,11 @@ class UNPKGDependencyProvider(DependencyProvider):
             ) as response:
                 metadata = await response.json()
 
-        ALLOWED_ASSET_TYPES = {
-            "text/html",
-            "text/javascript",
-            "text/markdown",
-            "text/plain",
-            "text/typescript",
-            "text/yaml",
-            "application/json",
-            "application/octet-stream",
-            "application/toml",
-        }
-
         assets = []
 
         def append_assets(data: Dict[str, Any]) -> None:
             for file in data["files"]:
-                if file["type"] in ALLOWED_ASSET_TYPES:
+                if file["type"] in UNPKG_ALLOWED_ASSET_TYPES:
                     assets.append(
                         AssetFile(
                             name=file["path"].lstrip("/"),

--- a/amass/cli.py
+++ b/amass/cli.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import shutil
 from functools import wraps
+from importlib.metadata import version
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Callable, Dict
@@ -9,7 +10,6 @@ from typing import Any, Callable, Dict
 import aiohttp
 import click
 import tomlkit
-from pkg_resources import get_distribution
 
 from amass import CONCURRENT_REQUESTS, parse_lock_file, parse_toml_file
 
@@ -36,7 +36,7 @@ def _get_settings() -> Dict[str, Path]:
 
 
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]))
-@click.version_option(get_distribution("amass").version, "-v", "--version")
+@click.version_option(version("amass"), "-v", "--version")
 def cli() -> None:
     pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,13 +61,14 @@ xfail_strict = true
 legacy_tox_ini = """
 [tox]
 isolated_build = True
-envlist = py38, py39, py310, py311
+envlist = py38, py39, py310, py311, py312
 [gh-actions]
 python =
     3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 [testenv]
 allowlist_externals =
     poetry


### PR DESCRIPTION
Fixes https://github.com/jmsmkn/amass/issues/6

And adds python 3.12 to tox and CI