### PR TITLE
Allow any text type as unpkg asset

### DIFF
--- a/amass/__init__.py
+++ b/amass/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import fnmatch
 import functools
 import hashlib
 import json
@@ -117,16 +118,18 @@ class CDNJSDependencyProvider(DependencyProvider):
 
 
 UNPKG_ALLOWED_ASSET_TYPES = {
-    "text/html",
-    "text/javascript",
-    "text/markdown",
-    "text/plain",
-    "text/typescript",
-    "text/yaml",
+    "text/*",
     "application/json",
     "application/octet-stream",
     "application/toml",
 }
+
+
+def is_allowed_asset_type(asset_type: str) -> bool:
+    for allowed in UNPKG_ALLOWED_ASSET_TYPES:
+        if fnmatch.fnmatch(asset_type, allowed):
+            return True
+    return False
 
 
 class UNPKGDependencyProvider(DependencyProvider):
@@ -173,7 +176,7 @@ class UNPKGDependencyProvider(DependencyProvider):
 
         def append_assets(data: dict[str, Any]) -> None:
             for file in data["files"]:
-                if file["type"] in UNPKG_ALLOWED_ASSET_TYPES:
+                if is_allowed_asset_type(file["type"]):
                     assets.append(
                         AssetFile(
                             name=file["path"].lstrip("/"),

--- a/tests/test_amass.py
+++ b/tests/test_amass.py
@@ -19,6 +19,7 @@ from amass import (
     ProviderVersion,
     generate_lock_file,
     get_dependency_provider,
+    is_allowed_asset_type,
     parse_dependencies,
     parse_lock_file,
     parse_toml_file,
@@ -347,3 +348,8 @@ async def test_dependency_provider_fetch_file(
     )
 
     assert content.decode().startswith("/*! jQuery v3.7.0 |")
+
+
+def test_is_allowed_asset_type_text_test():
+    assert is_allowed_asset_type("text/anything")
+    assert not is_allowed_asset_type("application/anything")


### PR DESCRIPTION
Real-world usage revealed that the allow list was not permissive enough. Any text file is fine to be used as asset.