### PR TITLE
Replace rename with shutil.move for output directory

### DIFF
--- a/amass/cli.py
+++ b/amass/cli.py
@@ -85,4 +85,4 @@ async def install() -> None:
             shutil.rmtree(output_dir)
 
         output_dir.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path.rename(output_dir)
+        shutil.move(str(tmp_path), str(output_dir))


### PR DESCRIPTION
`Path.rename()` failed on my machine because it does not handle cross-filesystem moving and `/tmp` is a `tmpfs`. `shutil.move()` does work.